### PR TITLE
make note template only editable in one-way sync

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -425,7 +425,7 @@ class FleetingNotesSettingTab extends PluginSettingTab {
 				t.inputEl.setAttr("rows", 10);
 				t.inputEl.addClass("note_template");
 				if (this.plugin.settings.sync_type == 'two-way') {
-					t.inputEl.setAttr("disabled", false);
+					t.inputEl.setAttr("disabled", true);
 				}
 			})
 			.addExtraButton(cb => {


### PR DESCRIPTION
Closes #5 

^ I know this isn't a solution but I believe this is the best way to handle this bug for now. If you desire two-way sync, while editing a note please submit a feature request!